### PR TITLE
Added configuration for circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2
+
+jobs:
+    deploy:
+        working_directory: ~/repo
+        docker:
+            - image: circleci/node:12.8.0
+        steps:
+            - checkout
+
+            - restore_cache:
+                  keys:
+                      - v1-dependencies-{{ checksum "package.json" }}
+                      # fallback to using the latest cache if no exact match is found
+                      - v1-dependencies-
+
+            - run: npm install
+
+            - save_cache:
+                  paths:
+                      - node_modules
+                  key: v1-dependencies-{{ checksum "package.json" }}
+            - run:
+                  name: Authenticate with registry
+                  command: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > ~/repo/.npmrc
+            - run:
+                  name: Publish package
+                  command: npm publish
+
+workflows:
+    version: 2
+    workflow:
+        jobs:
+            - deploy:
+                  filters:
+                      branches:
+                          only: master
+                      tags:
+                          only: /^v.*/


### PR DESCRIPTION
Added Configuration to publish npm package every time a tagged commit is pushed

Pre-requisite:
* Setup Circle-CI
* Set the $npm_TOKEN Environment Variable in CircleCI
  * Go to cmd and after typing `npm login`, run `cat ~/.npmrc` to know your npm token.
  * Use this token to add environment variable with name `npm_TOKEN` in circleCI config. [See more](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)
* Push normal commit, then publish a tag using 
```
git tag -a v2.0.1 -m "<message>"
git push -u origin v2.0.1
``` 
